### PR TITLE
Add team-driver-car-result relationships and team results endpoint

### DIFF
--- a/F1StatsAPI/Controllers/TeamController.cs
+++ b/F1StatsAPI/Controllers/TeamController.cs
@@ -35,6 +35,22 @@ namespace F1StatsAPI.Controllers
             return team;
         }
 
+        [HttpGet("{id}/results")]
+        public async Task<ActionResult<IEnumerable<Result>>> GetTeamResults(int id)
+        {
+            var team = await _context.Teams
+                .Include(t => t.Results)
+                .ThenInclude(t => t.GrandPrix)
+                .FirstOrDefaultAsync(t => t.Id == id);
+
+            if (team == null)
+            {
+                return NotFound();
+            }
+
+            return Ok(team.Results);
+        }
+
         [HttpPost]
         public async Task<ActionResult<Team>> AddTeam(Team team)
         {

--- a/F1StatsAPI/Models/Driver.cs
+++ b/F1StatsAPI/Models/Driver.cs
@@ -39,5 +39,10 @@ namespace F1StatsAPI.Models
         [DataType(DataType.Date)]
         [CustomValidation(typeof(DateValidator), nameof(DateValidator.ValidationBirthDate))]
         public DateTime DateOfBirth { get; set; }
+
+        [ForeignKey("Team")]
+        [Required]
+        public int TeamId { get; set; }
+        public required Team Team { get; set; }
     }
 }

--- a/F1StatsAPI/Models/Team.cs
+++ b/F1StatsAPI/Models/Team.cs
@@ -1,4 +1,7 @@
-﻿using System.ComponentModel.DataAnnotations;
+﻿using Microsoft.Identity.Client;
+using Microsoft.VisualBasic;
+using System.ComponentModel;
+using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
 
 namespace F1StatsAPI.Models
@@ -26,6 +29,14 @@ namespace F1StatsAPI.Models
 
         [Required]
         [Range(1900, 2100, ErrorMessage = "Foundation year must be between 1900 and 2100.")]
-        public int FoundationYear { get; set; } 
+        public int FoundationYear { get; set; }
+
+        [ForeignKey("Car")]
+        [Required]
+        public int CarId { get; set; }
+        public required Car Car { get; set; }
+
+        public List<Driver> Drivers { get; set; } = new();
+        public List<Result> Results { get; set; } = new();
     }
 }


### PR DESCRIPTION
Implemented team-driver-car relationships and added support for retrieving all results for a team. Prepares the structure for driver/team points logic.

