### PR TITLE
Implement ResultDTO with AutoMapper and custom RaceStatusResolver

### DIFF
--- a/F1StatsAPI/Controllers/DriverController.cs
+++ b/F1StatsAPI/Controllers/DriverController.cs
@@ -28,7 +28,7 @@ namespace F1StatsAPI.Controllers
         }
 
         [HttpGet("{id}")]
-        public async Task<ActionResult<Driver>> GetDriverById(int id)
+        public async Task<ActionResult<DriverDTO>> GetDriverById(int id)
         {
             var driver = await _driverService.GetDriverByIdAsync(id);
             if (driver == null) return NotFound();

--- a/F1StatsAPI/Controllers/ResultController.cs
+++ b/F1StatsAPI/Controllers/ResultController.cs
@@ -6,6 +6,7 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.VisualBasic;
 using System.Data.Common;
+using F1StatsAPI.DTOs;
 
 namespace F1StatsAPI.Controllers
 {
@@ -21,14 +22,14 @@ namespace F1StatsAPI.Controllers
         }
 
         [HttpGet]
-        public async Task<ActionResult<IEnumerable<Result>>> GetResults()
+        public async Task<ActionResult<IEnumerable<ResultDTO>>> GetResults()
         {
             var results = await _resultService.GetResultsAsync();
             return Ok(results);
         }
 
         [HttpGet("{id}")]
-        public async Task<ActionResult<Result>> GetResultById(int id)
+        public async Task<ActionResult<ResultDTO>> GetResultById(int id)
         {
             var existingResult = await _resultService.GetResultByIdAsync(id);
             if (existingResult == null) return NotFound();

--- a/F1StatsAPI/Controllers/TeamController.cs
+++ b/F1StatsAPI/Controllers/TeamController.cs
@@ -3,6 +3,7 @@ using F1StatsAPI.Data;
 using F1StatsAPI.Models;
 using Microsoft.EntityFrameworkCore;
 using F1StatsAPI.Services;
+using F1StatsAPI.DTOs;
 
 namespace F1StatsAPI.Controllers
 {
@@ -18,14 +19,14 @@ namespace F1StatsAPI.Controllers
         }
 
         [HttpGet]
-        public async Task<ActionResult<IEnumerable<Team>>> GetTeams()
+        public async Task<ActionResult<IEnumerable<TeamDTO>>> GetTeams()
         {
             var teams = await _teamService.GetTeamsAsync();
             return Ok(teams);
         }
 
         [HttpGet("{id}")]
-        public async Task<ActionResult<Team>> GetTeam(int id)
+        public async Task<ActionResult<TeamDTO>> GetTeam(int id)
         {
             var team = await _teamService.GetTeamByIdAsync(id);
             if (team == null) return NotFound();

--- a/F1StatsAPI/DTOs/ResultDTO.cs
+++ b/F1StatsAPI/DTOs/ResultDTO.cs
@@ -1,0 +1,16 @@
+﻿namespace F1StatsAPI.DTOs
+{
+    public class ResultDTO
+    {
+        public string GrandPrixName { get; set; } = string.Empty;
+        public DateTime GrandPrixDate { get; set; }
+
+        public string DriverName { get; set; } = string.Empty;
+        public string TeamName { get; set; } = string.Empty;
+
+        public int Position { get; set; }
+        public int Points { get; set; }
+
+        public string? RaceStatus { get; set; }
+    }
+}

--- a/F1StatsAPI/Mappings/AutoMapperProfile.cs
+++ b/F1StatsAPI/Mappings/AutoMapperProfile.cs
@@ -1,6 +1,7 @@
 ﻿using AutoMapper;
 using F1StatsAPI.DTOs;
 using F1StatsAPI.Models;
+using F1StatsAPI.Mappings;
 
 namespace F1StatsAPI.Mappings
 {
@@ -19,6 +20,22 @@ namespace F1StatsAPI.Mappings
                     opt => opt.MapFrom(src => 
                         src.Drivers.Select(d => d.GivenName + " " + d.FamilyName).ToList()
                     ));
+            // Mapping fields from related GrandPrix entity (null-safe)
+            CreateMap<Result, ResultDTO>()
+                .ForMember(dest => dest.GrandPrixName,
+                    opt => opt.MapFrom(src => src.GrandPrix != null ? src.GrandPrix.Name : null)) //GrandPrix NAME
+
+                .ForMember(dest => dest.GrandPrixDate,
+                    opt => opt.MapFrom(src => src.GrandPrix != null ? src.GrandPrix.Date : (DateTime?)null)) //GrandPrix DATE
+
+                .ForMember(dest => dest.DriverName,
+                    opt => opt.MapFrom(src => src.Driver != null ? src.Driver.GivenName + " " + src.Driver.FamilyName : null)) //Driver FULL NAME
+
+                .ForMember(dest => dest.TeamName,
+                    opt => opt.MapFrom(src => src.Team != null ? src.Team.Name : null)) //Team NAME
+
+                .ForMember(dest => dest.RaceStatus,
+                    opt => opt.MapFrom<RaceStatusResolver>()); //Race STATUS
         }
     }
 }

--- a/F1StatsAPI/Mappings/RaceStatusResolver.cs
+++ b/F1StatsAPI/Mappings/RaceStatusResolver.cs
@@ -1,0 +1,25 @@
+﻿using AutoMapper;
+using AutoMapper.Execution;
+using F1StatsAPI.DTOs;
+using F1StatsAPI.Models;
+using Microsoft.AspNetCore.Mvc.Infrastructure;
+
+namespace F1StatsAPI.Mappings
+{
+    public class RaceStatusResolver : IValueResolver<Result, ResultDTO, string?>
+    {
+        public string? Resolve (Result source, ResultDTO destination, string? destMember, ResolutionContext context)
+        {
+            if (!string.IsNullOrEmpty(source.Status))
+                return source.Status;
+
+            if (source.Position == 1 && source.Time != null)
+                return source.Time.Value.ToString();
+
+            if (!string.IsNullOrEmpty(source.GapToLeader))
+                return source.GapToLeader;
+
+            return "N/A";
+        }
+    }
+}

--- a/F1StatsAPI/Models/Result.cs
+++ b/F1StatsAPI/Models/Result.cs
@@ -33,5 +33,7 @@ namespace F1StatsAPI.Models
 
         [Required]
         public bool DidNotFinish { get; set; }
+
+        public string? Status { get; set; }
     }
 }

--- a/F1StatsAPI/Services/IResultService.cs
+++ b/F1StatsAPI/Services/IResultService.cs
@@ -1,11 +1,12 @@
 ﻿using F1StatsAPI.Models;
+using F1StatsAPI.DTOs;
 
 namespace F1StatsAPI.Services
 {
     public interface IResultService
     {
-        Task<IEnumerable<Result>> GetResultsAsync();
-        Task<Result?> GetResultByIdAsync(int id);
+        Task<IEnumerable<ResultDTO>> GetResultsAsync();
+        Task<ResultDTO?> GetResultByIdAsync(int id);
         Task<Result?> AddResultAsync(Result result);
         Task<bool> UpdateResultAsync(int id, Result result);
         Task<bool> DeleteResultAsync(int id);

--- a/F1StatsAPI/Services/ResultService.cs
+++ b/F1StatsAPI/Services/ResultService.cs
@@ -4,35 +4,41 @@ using F1StatsAPI.Data;
 using F1StatsAPI.Models;
 using Microsoft.AspNetCore.Http.HttpResults;
 using System.Runtime.InteropServices;
+using F1StatsAPI.DTOs;
+using AutoMapper;
 
 namespace F1StatsAPI.Services
 {
     public class ResultService : IResultService
     {
         private readonly F1StatsContext _context;
-        public ResultService(F1StatsContext context) 
+        private readonly Mapper _mapper;
+        public ResultService(F1StatsContext context, Mapper mapper) 
         {
             _context = context;
+            _mapper = mapper;
         }
 
-        public async Task<IEnumerable<Result>> GetResultsAsync()
+        public async Task<IEnumerable<ResultDTO>> GetResultsAsync()
         {
-            return await _context.Results
+            var results = await _context.Results
                 .Include(g => g.GrandPrix)
                 .Include(t => t.Team)
                 .Include(d => d.Driver)
                 .Include(c => c.Car)
                 .ToListAsync();
+            return _mapper.Map<IEnumerable<ResultDTO>>(results);
         }
 
-        public async Task<Result?> GetResultByIdAsync(int id)
+        public async Task<ResultDTO?> GetResultByIdAsync(int id)
         {
-            return await _context.Results
+            var result = await _context.Results
                 .Include(g => g.GrandPrix)
                 .Include(t => t.Team)
                 .Include(d => d.Driver)
                 .Include(c => c.Car)
                 .FirstOrDefaultAsync(r => r.Id == id);
+            return _mapper.Map<ResultDTO?>(result);
         }
 
         public async Task<Result?> AddResultAsync(Result result)


### PR DESCRIPTION
This merge introduces ResultDTO for data transfer and display purposes. The mapping logic includes a custom RaceStatusResolver to format the race result (time, gap, or DNF status). Controller and service methods for GET operations were updated to use DTOs.