### PR TITLE
git commit -m "Fix birthdate format in DriverDTO"

### DIFF
--- a/F1StatsAPI/DTOs/DriverDTO.cs
+++ b/F1StatsAPI/DTOs/DriverDTO.cs
@@ -6,7 +6,7 @@
         public string Code { get; set; } = string.Empty;
         public string GivenName { get; set; } = string.Empty;
         public string FamilyName { get; set; } = string.Empty;
-        public DateTime BirthDate { get; set; }
+        public string BirthDate { get; set; } = string.Empty;
         public string Country { get; set; } = string.Empty;
         public string? TeamName { get; set; }
     }

--- a/F1StatsAPI/Mappings/DriverProfile.cs
+++ b/F1StatsAPI/Mappings/DriverProfile.cs
@@ -1,4 +1,5 @@
 ﻿using AutoMapper;
+using System.Globalization;
 using F1StatsAPI.DTOs;
 using F1StatsAPI.Models;
 
@@ -10,7 +11,9 @@ namespace F1StatsAPI.Mappings
         {
             CreateMap<Driver, DriverDTO>()
                 .ForMember(dest => dest.TeamName,
-                 opt => opt.MapFrom(src => src.Team != null ? src.Team.Name : null));
+                    opt => opt.MapFrom(src => src.Team != null ? src.Team.Name : null))
+                .ForMember(dest => dest.BirthDate,
+                    opt => opt.MapFrom(src => src.DateOfBirth.ToString("dd MMMM yyyy", CultureInfo.InvariantCulture)));
         }
     }
 }


### PR DESCRIPTION
This pull request fixes the BirthDate field format in DriverDTO by applying a custom ToString("dd MMMM yyyy") conversion in DriverProfile. Dates are now displayed in a human-readable format in API responses (e.g. 16 October 1997). Tested successfully in Postman.